### PR TITLE
Support nested sectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To add or change style sets, simply add or change an array with classes that sho
     'li p' => 'mb-2 ml-4',
 ],
 ```
-*This example uses TailwindCSS, but you can use whater kind of CSS you want.*
+*This example uses TailwindCSS, but you can use whatever kind of CSS you want.*
 
 ### Example Output
 ```html

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If you want to add multiple style sets, define those in the config file. For exa
 ## Nested selectors (min version 2.2)
 You can nest your selectors to flexible style elements in different contexts. 
 
-let's assume you want to style links inside lists differenlty than a general link, you can make use of nesting:
+Let's assume you want to style links inside lists differently than a general link, you can make use of nesting:
 ```php
 `ul li p a` => 'my-secial-css-class-for-nested-links-in-lists`,
 `a` => `a-general-link-class`,

--- a/README.md
+++ b/README.md
@@ -2,22 +2,7 @@
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/visuellverstehen/statamic-classify.svg?style=for-the-badge)](https://packagist.org/packages/visuellverstehen/statamic-classify)
 
 # Classify
-Classify is a useful helper to add CSS classes to all of your HTML tags, created by the [Bard](https://statamic.dev/fieldtypes/bard) editor. 
-
-## What it does
-Bards default output would be:
-```html
-<h1>A nice headline</h1>
-<p>Something really <a href="#">important</a></p>
-```
-
-Would you like to add some classes to different HTML tags?
-```html
-<h1 class="text-2xl">A nice headline</h1>
-<p>Something really <a class="link hover:blue" href="#">important</a></p>
-```
-
-In that case, Classify will be your friend.
+Classify is a useful helper to add CSS classes to your HTML tags, created by the Statamic 3 [Bard](https://statamic.dev/fieldtypes/bard) editor. 
 
 # Installation
 
@@ -34,8 +19,9 @@ In that case, Classify will be your friend.
 | ^1.0      |  3.0     |  ^7.0
 | ^2.0      |  3.0     |  ^8.0
 | ^2.1      |  3.1     |  ^8.0
+| ^2.2      |  3.1     |  ^8.0
 
-## Install addon
+## Installation
 
 There are two ways to install the Classify addon.
 
@@ -61,9 +47,26 @@ The installation process will automatically publish the `classify.php` file into
 To add or change style sets, simply add or change an array with classes that should be added to the HTML tag.
 ```php
 'default' => [
-        'h1' => 'text-2xl',
-        'a'  => 'link hover:blue',
-    ],
+    'h1' => 'text-2xl',
+    'a'  => 'link hover:text-blue',
+    'p' => 'mb-5',
+    'li p' => 'mb-2 ml-4',
+],
+```
+*This example uses TailwindCSS, but you can use whater kind of css you want.*
+
+### Example Output
+```html
+<h1 class="text-2xl">A headline</h1>
+<p class="mb-5">Some text</p>
+
+<ul>
+    <li><p class="mb-2 ml-4">A list item</p></li>
+    <li><p class="mb-2 ml-4">A list item</p></li>
+    <li><p class="mb-2 ml-4"><a class="link hover:text-blue" href="#">Klick me</a></p></li>
+</ul>
+
+<p class="mb-5">Another text</p>
 ```
 
 ### Usage
@@ -75,15 +78,30 @@ If you want to use the default style set, use the `classify` modifier.
 
 If you want to add multiple style sets, define those in the config file. For example:
 ```php
-// config
+'default' => [
+    // 
+],
 'blog' => [
-    'button' => 'button button--blue',
-    'a'  => 'link',
+    'a'  => 'link hover:underline',
+    'li p' => 'ml-3 font-bold',
+    'p' => 'mb-5',
 ],
 
 // Antlers view
 {{ bard_text | classify:blog }}
 ```
+
+## Nested selectors (min version 2.2)
+You can nest your selectors to flexible style elements in different contexts. 
+
+let's assume you want to style links inside lists differenlty than a general link, you can make use of nesting:
+```php
+`ul li p a` => 'my-secial-css-class-for-nested-links-in-lists`,
+`a` => `a-general-link-class`,
+```
+
+The ordering does not matter. Classify will take care of that for you.
+
 
 # More about us
 - [www.statamic-agency.com](https://statamic-agency.com)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ To add or change style sets, simply add or change an array with classes that sho
     'li p' => 'mb-2 ml-4',
 ],
 ```
-*This example uses TailwindCSS, but you can use whater kind of css you want.*
+*This example uses TailwindCSS, but you can use whater kind of CSS you want.*
 
 ### Example Output
 ```html

--- a/src/ClassifyParser.php
+++ b/src/ClassifyParser.php
@@ -4,5 +4,5 @@ namespace VV\Classify;
 
 interface ClassifyParser
 {
-    public function parse(string $tags, string $classes, string $value): string;
+    public function parse(Tag $tag, string $value): string;
 }

--- a/src/ClassifyParser.php
+++ b/src/ClassifyParser.php
@@ -4,5 +4,5 @@ namespace VV\Classify;
 
 interface ClassifyParser
 {
-    public function parse(string $tag, string $class, string $value): string;
+    public function parse(string $tags, string $classes, string $value): string;
 }

--- a/src/HtmlParser.php
+++ b/src/HtmlParser.php
@@ -4,36 +4,28 @@ namespace VV\Classify;
 
 class HtmlParser implements ClassifyParser
 {
-    public function parse(string $tags, string $classes, string $value): string
+    public function parse(Tag $tag, string $value): string
     {
-        $tags = explode(' ', $tags);
-        $last = $this->getLastTagAndRemove($tags);
-
         return preg_replace(
-            $this->defineRegexPattern($tags, $last),
-            $this->defineReplacement($classes, $last),
+            $this->defineRegexPattern($tag),
+            $this->defineReplacement($tag),
             $value
         );
     }
 
-    private function getLastTagAndRemove(array &$tags): string
-    {
-        return array_splice($tags, array_key_last($tags))[0];
-    }
-
-    private function defineRegexPattern(array $tags, string $last): string
+    private function defineRegexPattern(Tag $tag): string
     {
         $pattern = '';
 
-        foreach ($tags as $tag) {
-            $pattern .= "<{$tag}[^>]*>[^<]*";
+        foreach ($tag->before as $name) {
+            $pattern .= "<{$name}[^>]*>[^<]*";
         }
 
-        return "/({$pattern})(<{$last})/iU";
+        return "/({$pattern})(<{$tag->tag})(?! class)/iU";
     }
 
-    private function defineReplacement(string $classes, string $last): string
+    private function defineReplacement(Tag $tag): string
     {
-        return "$1<{$last} class=\"{$classes}\"";
+        return "$1<{$tag->tag} class=\"{$tag->classes}\"";
     }
 }

--- a/src/HtmlParser.php
+++ b/src/HtmlParser.php
@@ -4,9 +4,13 @@ namespace VV\Classify;
 
 class HtmlParser implements ClassifyParser
 {
-    public function parse(string $tag, string $class, string $value): string
+    public function parse(string $tags, string $classes, string $value): string
     {
-        return str_replace($this->tagFilter($tag), $this->replaceTag($tag, $class), $value);
+        if ($this->isSingleTag($tags)) {
+            return str_replace($this->tagFilter($tags), $this->replaceTag($tags, $classes), $value);
+        }
+
+        return $value;
     }
 
     /**
@@ -23,5 +27,10 @@ class HtmlParser implements ClassifyParser
     private function replaceTag(string $tag, string $class): string
     {
         return "<{$tag} class=\"{$class}\"";
+    }
+
+    private function isSingleTag(string $tags): bool
+    {
+        return count(explode(' ', $tags)) === 1;
     }
 }

--- a/src/HtmlParser.php
+++ b/src/HtmlParser.php
@@ -6,31 +6,34 @@ class HtmlParser implements ClassifyParser
 {
     public function parse(string $tags, string $classes, string $value): string
     {
-        if ($this->isSingleTag($tags)) {
-            return str_replace($this->tagFilter($tags), $this->replaceTag($tags, $classes), $value);
+        $tags = explode(' ', $tags);
+        $last = $this->getLastTagAndRemove($tags);
+
+        return preg_replace(
+            $this->defineRegexPattern($tags, $last),
+            $this->defineReplacement($classes, $last),
+            $value
+        );
+    }
+
+    private function getLastTagAndRemove(array &$tags): string
+    {
+        return array_splice($tags, array_key_last($tags))[0];
+    }
+
+    private function defineRegexPattern(array $tags, string $last): string
+    {
+        $pattern = '';
+
+        foreach ($tags as $tag) {
+            $pattern .= "<{$tag}[^>]*>[^<]*";
         }
 
-        return $value;
+        return "/({$pattern})(<{$last})/iU";
     }
 
-    /**
-     * Build string wich should be replaced.
-     */
-    private function tagFilter(string $tag): string
+    private function defineReplacement(string $classes, string $last): string
     {
-        return "<{$tag}";
-    }
-
-    /**
-     * Replace filtered tag and add css classes.
-     */
-    private function replaceTag(string $tag, string $class): string
-    {
-        return "<{$tag} class=\"{$class}\"";
-    }
-
-    private function isSingleTag(string $tags): bool
-    {
-        return count(explode(' ', $tags)) === 1;
+        return "$1<{$last} class=\"{$classes}\"";
     }
 }

--- a/src/Modifiers/Classify.php
+++ b/src/Modifiers/Classify.php
@@ -24,8 +24,8 @@ class Classify extends Modifier
         // The styleset wich will be applied.
         $styleSegments = config('classify.'.$styleset);
 
-        foreach ($styleSegments as $tag => $class) {
-            $value = app(ClassifyParser::class)->parse($tag, $class, $value);
+        foreach ($styleSegments as $tags => $classes) {
+            $value = app(ClassifyParser::class)->parse($tags, $classes, $value);
         }
 
         return $value;

--- a/src/Modifiers/Classify.php
+++ b/src/Modifiers/Classify.php
@@ -30,7 +30,7 @@ class Classify extends Modifier
             ->map(fn ($classes, $tags) => new Tag($tags, $classes))
             ->sortByDesc('count');
 
-        $segments->each(function($segment) use (&$value) {
+        $segments->each(function ($segment) use (&$value) {
             $value = app(ClassifyParser::class)->parse($segment, $value);
         });
 

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -32,7 +32,6 @@ class Tag
         $this->count = count($tags);
         $this->classes = $classes;
         $this->setTags($tags);
-
     }
 
     /*

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace VV\Classify;
+
+class Tag
+{
+    /*
+     * Contains the parent tag, which might be the only or last tag defined in the config.
+     * From a list like `ul li p` it would fx be `p`.
+     */
+    public string $tag;
+
+    /*
+     * If multiple tags have been defined, those are the tags before the parent tag.
+     * From a list like `ul li p` it would fx be `ul li`.
+     */
+    public array $before;
+
+    /*
+     * Contains the class list as defined in the config.
+     */
+    public string $classes;
+
+    /*
+     * Defines the number of tags, including the parent tag.
+     */
+    public int $count;
+
+    public function __construct(string $tags, string $classes) {
+        $tags = $this->convertTagsToArray($tags);
+        $this->count = count($tags);
+        $this->classes = $classes;
+        $this->setTags($tags);
+
+    }
+
+    /*
+     * It's easier to handle tags as an array, so we'll convert them.
+     */
+    private function convertTagsToArray(string $tags): array
+    {
+        return explode(' ', $tags);
+    }
+
+    /*
+     * Set the parent tag and save all other tags in the before attribute.
+     */
+    private function setTags(array $tags): void
+    {
+        $this->tag = $this->setParentTagAndRemoveFromOriginalArray($tags);
+        $this->before = $tags;
+    }
+
+    /*
+     * Get the key from the last array and splice / remove it.
+     */
+    private function setParentTagAndRemoveFromOriginalArray(array &$tags)
+    {
+        return array_splice($tags, array_key_last($tags))[0];
+    }
+}

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -26,7 +26,8 @@ class Tag
      */
     public int $count;
 
-    public function __construct(string $tags, string $classes) {
+    public function __construct(string $tags, string $classes)
+    {
         $tags = $this->convertTagsToArray($tags);
         $this->count = count($tags);
         $this->classes = $classes;

--- a/tests/Unit/ClassifyTest.php
+++ b/tests/Unit/ClassifyTest.php
@@ -131,4 +131,38 @@ class ClassifyTest extends TestCase
 
         $this->assertEquals('<a href="#">Some<span class="text-red">thing</span></a>', $classified);
     }
+
+    /** @test */
+    public function a_nested_tag_will_be_replaced_and_wont_be_overwritten()
+    {
+        $config = [
+            'default'  => [
+                'p' => 'single',
+                'li p' => 'nested',
+            ],
+        ];
+
+        Config::set('classify', $config);
+
+        $bardInput = <<<EOT
+                     <li>
+                        <p>I am nested</p>
+                     </li>
+                     
+                     <p>I am not</p>
+                     EOT;
+
+        $expedtedOutput = <<<EOT
+                          <li>
+                             <p class="nested">I am nested</p>
+                          </li>
+                          
+                          <p class="single">I am not</p>
+                          EOT;
+
+
+        $classified = $this->classify->index($bardInput, [], []);
+
+        $this->assertEquals($expedtedOutput, $classified);
+    }
 }

--- a/tests/Unit/ClassifyTest.php
+++ b/tests/Unit/ClassifyTest.php
@@ -96,13 +96,13 @@ class ClassifyTest extends TestCase
 
         Config::set('classify', $config);
 
-        $bardInput = <<<EOT
+        $bardInput = <<<'EOT'
                      <li>Bad formatted HTML
                         <p>Some more</p>
                      </li>
                      EOT;
 
-        $expedtedOutput = <<<EOT
+        $expedtedOutput = <<<'EOT'
                           <li>Bad formatted HTML
                              <p class="text-bold">Some more</p>
                           </li>
@@ -144,7 +144,7 @@ class ClassifyTest extends TestCase
 
         Config::set('classify', $config);
 
-        $bardInput = <<<EOT
+        $bardInput = <<<'EOT'
                      <li>
                         <p>I am nested</p>
                      </li>
@@ -152,7 +152,7 @@ class ClassifyTest extends TestCase
                      <p>I am not</p>
                      EOT;
 
-        $expedtedOutput = <<<EOT
+        $expedtedOutput = <<<'EOT'
                           <li>
                              <p class="nested">I am nested</p>
                           </li>

--- a/tests/Unit/ClassifyTest.php
+++ b/tests/Unit/ClassifyTest.php
@@ -59,10 +59,76 @@ class ClassifyTest extends TestCase
 
         Config::set('classify', $config);
 
-        $bardInput = '<li><p>Some text</p>';
+        $bardInput = '<li><p>Some text</p></li>';
 
         $classified = $this->classify->index($bardInput, [], []);
 
-        $this->assertEquals('<li><p>Some text</p>><p class="text-sm">Some text</p>', $classified);
+        $this->assertEquals('<li><p class="text-sm">Some text</p></li>', $classified);
+    }
+
+
+    /** @test */
+    public function a_nested_tag_with_text_inbetween_will_be_recognized()
+    {
+        $config = [
+            'default'  => [
+                'a span' => 'text-red',
+            ],
+        ];
+
+        Config::set('classify', $config);
+
+        $bardInput = '<a>Some <span>styled</span> text</a>';
+
+        $classified = $this->classify->index($bardInput, [], []);
+
+        $this->assertEquals('<a>Some <span class="text-red">styled</span> text</a>', $classified);
+    }
+
+    /** @test */
+    public function a_nested_tag_with_text_inbetween_will_be_recognized_on_multilines_as_well()
+    {
+        $config = [
+            'default'  => [
+                'li p' => 'text-bold',
+            ],
+        ];
+
+        Config::set('classify', $config);
+
+        $bardInput = <<<EOT
+                     <li>Bad formatted HTML
+                        <p>Some more</p>
+                     </li>
+                     EOT;
+
+        $expedtedOutput = <<<EOT
+                          <li>Bad formatted HTML
+                             <p class="text-bold">Some more</p>
+                          </li>
+                          EOT;
+
+
+        $classified = $this->classify->index($bardInput, [], []);
+
+        $this->assertEquals($expedtedOutput, $classified);
+    }
+
+    /** @test */
+    public function a_nested_tag_with_already_defined_classes_will_be_parsed_correctly()
+    {
+        $config = [
+            'default'  => [
+                'a span' => 'text-red',
+            ],
+        ];
+
+        Config::set('classify', $config);
+
+        $bardInput = '<a href="#">Some<span>thing</span></a>';
+
+        $classified = $this->classify->index($bardInput, [], []);
+
+        $this->assertEquals('<a href="#">Some<span class="text-red">thing</span></a>', $classified);
     }
 }

--- a/tests/Unit/ClassifyTest.php
+++ b/tests/Unit/ClassifyTest.php
@@ -66,7 +66,6 @@ class ClassifyTest extends TestCase
         $this->assertEquals('<li><p class="text-sm">Some text</p></li>', $classified);
     }
 
-
     /** @test */
     public function a_nested_tag_with_text_inbetween_will_be_recognized()
     {
@@ -107,7 +106,6 @@ class ClassifyTest extends TestCase
                              <p class="text-bold">Some more</p>
                           </li>
                           EOT;
-
 
         $classified = $this->classify->index($bardInput, [], []);
 
@@ -159,7 +157,6 @@ class ClassifyTest extends TestCase
                           
                           <p class="single">I am not</p>
                           EOT;
-
 
         $classified = $this->classify->index($bardInput, [], []);
 

--- a/tests/Unit/ClassifyTest.php
+++ b/tests/Unit/ClassifyTest.php
@@ -18,6 +18,8 @@ class ClassifyTest extends TestCase
             'default'  => [
                 'h1' => 'headline',
                 'a'  => 'link',
+                'p' => 'text-base',
+                'li p' => 'text-sm',
             ],
         ];
 
@@ -44,5 +46,23 @@ class ClassifyTest extends TestCase
         $classified = $this->classify->index($bardInput, [], []);
 
         $this->assertEquals('<a class="link" href="#">Link</a>', $classified);
+    }
+
+    /** @test */
+    public function a_nested_tag_will_be_recognized()
+    {
+        $config = [
+            'default'  => [
+                'li p' => 'text-sm',
+            ],
+        ];
+
+        Config::set('classify', $config);
+
+        $bardInput = '<li><p>Some text</p>';
+
+        $classified = $this->classify->index($bardInput, [], []);
+
+        $this->assertEquals('<li><p>Some text</p>><p class="text-sm">Some text</p>', $classified);
     }
 }


### PR DESCRIPTION
This PR adds the possibility to define nested tags. 

You can define and combine a syntax like: 
```php
`li p` => 'nested`
`p` => `single`
```

The order does not matter. In any case, nested tags will be replaced first and will not be overwritten by `less nested` tag classes. 

The above example would give the following result:
```html
<p class="single">Something</p>

<ul>
  <li><p class="nested">A list item</p></li>
</ul>

<p class="single">Something different</p>
```

Everything has been swapped to use regex to replace all classes. To not overcomplicate things, I tried to keep it as simple as possible. It's covered by tests, but before merging we need to test if it does work in a real-life-context, which I hadn't had the chance to do yet. 

**Provided feedback is appreciated a lot!**

Closes #12 