### PR TITLE
Prevent error for empty bard fields

### DIFF
--- a/src/Modifiers/Classify.php
+++ b/src/Modifiers/Classify.php
@@ -18,7 +18,7 @@ class Classify extends Modifier
     {
         $styleSet = $params[0] ?? 'default';
 
-        if (! $this->isStyleSetAvailable($styleSet)) {
+        if ((! $this->isStyleSetAvailable($styleSet)) || (null === $value)) {
             return $value;
         }
 


### PR DESCRIPTION
Currently empty bard fields throw an error message when using classify to try and output them: `Argument 2 passed to VV\Classify\HtmlParser::parse() must be of the type string, null given`

This is especially noticeable when using live preview - any time you add an empty bard field the preview switches to the error screen until you've added content to your bard field. Note: I only tested this with text-only (no available sets) bard fields, but it's definitely an issue for those. I can only assume other empty fields might have similar problems.

Fixing it by returning the original value when it's null, which leads to the expected empty output on our site.