### PR TITLE
Remove redundant laravel/framework constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,7 @@
     },
     "require": {
         "php": "^8.2 || ^8.3 || ^8.4",
-        "laravel/framework": "^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "statamic/cms": "^4.0 || ^5.0 || ^6.0 || dev-laravel-13",
+        "statamic/cms": "^4.0 || ^5.0 || ^6.0",
         "symfony/dom-crawler": "^6.0 || ^7.0 || ^8.0",
         "symfony/css-selector": "^5.4 || ^6.0 || ^7.0 || ^8.0"
     },


### PR DESCRIPTION
The `laravel/framework` dependency is already defined by `statamic/cms`, making the explicit constraint in this package unnecessary. Removing it means this package no longer needs to be updated every time a new Laravel major version is released.

Also cleans up the `dev-laravel-13` branch reference from the `statamic/cms` constraint, which is no longer needed after #47 was merged.

Ref: https://github.com/visuellverstehen/statamic-classify/pull/47#issuecomment-4114986338