### PR TITLE
test: migrate test suite to Pest 4 and fix CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,34 +8,34 @@ on:
 
 jobs:
   php-tests:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         php: [8.4, 8.3, 8.2]
-        laravel: ['10.*', '11.*', '12.*', '13.*']
-        statamic: ['5.*', '4.*']
-        dependency-version: [prefer-lowest, prefer-stable]
+        laravel: ['11.*', '12.*', '13.*']
+        statamic: ['5.*', '6.*']
         include:
-          - laravel: 12.*
-            testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
-          - laravel: 10.*
-            testbench: 8.*
+          - laravel: 12.*
+            testbench: 10.*
           - laravel: 13.*
             testbench: 11.*
         exclude:
           - laravel: 13.*
             php: 8.2
+          - laravel: 13.*
+            statamic: 5.*
+          - laravel: 11.*
+            statamic: 6.*
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - S${{ matrix.statamic }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - S${{ matrix.statamic }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -46,8 +46,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" ${{ matrix.additional-deps }} --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+          composer require "laravel/framework:${{ matrix.laravel }}" "statamic/cms:${{ matrix.statamic }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --prefer-stable --prefer-dist --no-interaction --no-suggest
 
-      - name: Run PHPUnit
+      - name: Run tests
         run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.4, 8.3, 8.2]
+        php: [8.4, 8.3]
         laravel: ['11.*', '12.*', '13.*']
         statamic: ['5.*', '6.*']
         include:
@@ -24,8 +24,6 @@ jobs:
           - laravel: 13.*
             testbench: 11.*
         exclude:
-          - laravel: 13.*
-            php: 8.2
           - laravel: 13.*
             statamic: 5.*
           - laravel: 11.*

--- a/composer.json
+++ b/composer.json
@@ -33,18 +33,18 @@
         "email": "hello@visuellverstehen.de"
     },
     "require": {
-        "php": "^8.2 || ^8.3 || ^8.4",
+        "php": "^8.2",
         "statamic/cms": "^4.0 || ^5.0 || ^6.0",
         "symfony/dom-crawler": "^6.0 || ^7.0 || ^8.0",
         "symfony/css-selector": "^5.4 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8 || ^9 || ^10 || ^11.0",
-        "phpunit/phpunit": "^9.3 || ^10.0 || ^11.5.3 || ^12.5.12"
+        "orchestra/testbench": "^9.17 || ^10.11 || ^11.0",
+        "pestphp/pest": "^4.0"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
+        "test": "vendor/bin/pest",
+        "test-coverage": "vendor/bin/pest --coverage"
     },
     "extra": {
         "statamic": {
@@ -59,7 +59,8 @@
     },
     "config": {
         "allow-plugins": {
-            "pixelfear/composer-dist-plugin": false
+            "pixelfear/composer-dist-plugin": false,
+            "pestphp/pest-plugin": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "email": "hello@visuellverstehen.de"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "statamic/cms": "^4.0 || ^5.0 || ^6.0",
         "symfony/dom-crawler": "^6.0 || ^7.0 || ^8.0",
         "symfony/css-selector": "^5.4 || ^6.0 || ^7.0 || ^8.0"

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,7 @@
     },
     "require": {
         "php": "^8.2 || ^8.3 || ^8.4",
-        "laravel/framework": "^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "statamic/cms": "^4.0 || ^5.0 || ^6.0 || dev-laravel-13",
+        "statamic/cms": "^4.0 || ^5.0 || ^6.0",
         "symfony/dom-crawler": "^6.0 || ^7.0 || ^8.0",
         "symfony/css-selector": "^5.4 || ^6.0 || ^7.0 || ^8.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit 
+<phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
-    bootstrap="vendor/autoload.php" 
-    backupGlobals="false" 
-    cacheResult="true" 
-    colors="true" 
-    processIsolation="false" 
-    stopOnFailure="false"  
-    cacheDirectory=".phpunit.cache" 
-    backupStaticProperties="false">
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="Unit">
       <directory suffix="Test.php">./tests/Unit/</directory>

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,5 @@
+<?php
+
+use VV\Classify\Tests\TestCase;
+
+uses(TestCase::class)->in('Unit');

--- a/tests/Unit/ClassifyTest.php
+++ b/tests/Unit/ClassifyTest.php
@@ -1,149 +1,75 @@
 <?php
 
-namespace VV\Classify\Tests\Unit;
-
 use Illuminate\Support\Facades\Config;
 use VV\Classify\Modifiers\Classify;
-use VV\Classify\Tests\TestCase;
 
-class ClassifyTest extends TestCase
-{
-    protected Classify $classify;
+beforeEach(function () {
+    Config::set('classify', [
+        'default' => [
+            'h1' => 'headline',
+            'a'  => 'link',
+            'p' => 'text-base',
+            'li p' => 'text-sm',
+            'strong, em' => 'text-red',
+        ],
+    ]);
 
-    public function setUp(): void
-    {
-        parent::setUp();
+    $this->classify = new Classify();
+});
 
-        $config = [
-            'default'  => [
-                'h1' => 'headline',
-                'a'  => 'link',
-                'p' => 'text-base',
-                'li p' => 'text-sm',
-                'strong, em' => 'text-red',
-            ],
-        ];
+it('applies class to a single tag', function () {
+    expect($this->classify->index('<h1>Hello world</h1>', [], []))
+        ->toBe('<h1 class="headline">Hello world</h1>');
+});
 
-        Config::set('classify', $config);
+it('applies class to a tag with existing attributes', function () {
+    expect($this->classify->index('<a href="#">Link</a>', [], []))
+        ->toBe('<a href="#" class="link">Link</a>');
+});
 
-        $this->classify = new Classify();
-    }
+it('recognizes a nested selector', function () {
+    Config::set('classify', ['default' => ['li p' => 'text-sm']]);
 
-    /** @test */
-    public function a_single_tag_will_be_extended_with_the_given_class_names()
-    {
-        $bardInput = '<h1>Hello world</h1>';
+    expect($this->classify->index('<li><p>Some text</p></li>', [], []))
+        ->toBe('<li><p class="text-sm">Some text</p></li>');
+});
 
-        $classified = $this->classify->index($bardInput, [], []);
+it('recognizes a nested tag with text in between', function () {
+    Config::set('classify', ['default' => ['a span' => 'text-red']]);
 
-        $this->assertEquals('<h1 class="headline">Hello world</h1>', $classified);
-    }
+    expect($this->classify->index('<a>Some <span>styled</span> text</a>', [], []))
+        ->toBe('<a>Some <span class="text-red">styled</span> text</a>');
+});
 
-    /** @test */
-    public function a_singletag_will_be_extended_with_the_given_class_names()
-    {
-        $bardInput = '<a href="#">Link</a>';
+it('handles nested tags across multiple lines', function () {
+    Config::set('classify', ['default' => ['li p' => 'text-bold']]);
 
-        $classified = $this->classify->index($bardInput, [], []);
-
-        $this->assertEquals('<a href="#" class="link">Link</a>', $classified);
-    }
-
-    /** @test */
-    public function a_nested_tag_will_be_recognized()
-    {
-        $config = [
-            'default'  => [
-                'li p' => 'text-sm',
-            ],
-        ];
-
-        Config::set('classify', $config);
-
-        $bardInput = '<li><p>Some text</p></li>';
-
-        $classified = $this->classify->index($bardInput, [], []);
-
-        $this->assertEquals('<li><p class="text-sm">Some text</p></li>', $classified);
-    }
-
-    /** @test */
-    public function a_nested_tag_with_text_inbetween_will_be_recognized()
-    {
-        $config = [
-            'default'  => [
-                'a span' => 'text-red',
-            ],
-        ];
-
-        Config::set('classify', $config);
-
-        $bardInput = '<a>Some <span>styled</span> text</a>';
-
-        $classified = $this->classify->index($bardInput, [], []);
-
-        $this->assertEquals('<a>Some <span class="text-red">styled</span> text</a>', $classified);
-    }
-
-    /** @test */
-    public function a_nested_tag_with_text_inbetween_will_be_recognized_on_multilines_as_well()
-    {
-        $config = [
-            'default'  => [
-                'li p' => 'text-bold',
-            ],
-        ];
-
-        Config::set('classify', $config);
-
-        $bardInput = <<<'EOT'
+    $input = <<<'EOT'
                      <li>Bad formatted HTML
                         <p>Some more</p>
                      </li>
                      EOT;
 
-        $expedtedOutput = <<<'EOT'
+    $expected = <<<'EOT'
                           <li>Bad formatted HTML
                              <p class="text-bold">Some more</p>
                           </li>
                           EOT;
 
-        $classified = $this->classify->index($bardInput, [], []);
+    expect($this->classify->index($input, [], []))->toBe($expected);
+});
 
-        $this->assertEquals($expedtedOutput, $classified);
-    }
+it('parses nested tags with already defined classes', function () {
+    Config::set('classify', ['default' => ['a span' => 'text-red']]);
 
-    /** @test */
-    public function a_nested_tag_with_already_defined_classes_will_be_parsed_correctly()
-    {
-        $config = [
-            'default'  => [
-                'a span' => 'text-red',
-            ],
-        ];
+    expect($this->classify->index('<a href="#">Some<span>thing</span></a>', [], []))
+        ->toBe('<a href="#">Some<span class="text-red">thing</span></a>');
+});
 
-        Config::set('classify', $config);
+it('replaces nested selectors without overwriting simpler ones', function () {
+    Config::set('classify', ['default' => ['p' => 'single', 'li p' => 'nested']]);
 
-        $bardInput = '<a href="#">Some<span>thing</span></a>';
-
-        $classified = $this->classify->index($bardInput, [], []);
-
-        $this->assertEquals('<a href="#">Some<span class="text-red">thing</span></a>', $classified);
-    }
-
-    /** @test */
-    public function a_nested_tag_will_be_replaced_and_wont_be_overwritten()
-    {
-        $config = [
-            'default'  => [
-                'p' => 'single',
-                'li p' => 'nested',
-            ],
-        ];
-
-        Config::set('classify', $config);
-
-        $bardInput = <<<'EOT'
+    $input = <<<'EOT'
                      <li>
                         <p>I am nested</p>
                      </li>
@@ -151,7 +77,7 @@ class ClassifyTest extends TestCase
                      <p>I am not</p>
                      EOT;
 
-        $expedtedOutput = <<<'EOT'
+    $expected = <<<'EOT'
                           <li>
                              <p class="nested">I am nested</p>
                           </li>
@@ -159,24 +85,13 @@ class ClassifyTest extends TestCase
                           <p class="single">I am not</p>
                           EOT;
 
-        $classified = $this->classify->index($bardInput, [], []);
+    expect($this->classify->index($input, [], []))->toBe($expected);
+});
 
-        $this->assertEquals($expedtedOutput, $classified);
-    }
+it('assigns classes to all matching list items', function () {
+    Config::set('classify', ['default' => ['ul' => 'parent', 'ul li' => 'nested']]);
 
-    /** @test */
-    public function all_list_items_will_be_assigned_to_a_class()
-    {
-        $config = [
-            'default'  => [
-                'ul' => 'parent',
-                'ul li' => 'nested',
-            ],
-        ];
-
-        Config::set('classify', $config);
-
-        $bardInput = <<<'EOT'
+    $input = <<<'EOT'
                      <ul>
                         <li>I am nested 1</li>
                         <li>I am nested 2</li>
@@ -184,7 +99,7 @@ class ClassifyTest extends TestCase
                      </ul>
                      EOT;
 
-        $expedtedOutput = <<<'EOT'
+    $expected = <<<'EOT'
                           <ul class="parent">
                              <li class="nested">I am nested 1</li>
                              <li class="nested">I am nested 2</li>
@@ -192,29 +107,21 @@ class ClassifyTest extends TestCase
                           </ul>
                           EOT;
 
-        $classified = $this->classify->index($bardInput, [], []);
+    expect($this->classify->index($input, [], []))->toBe($expected);
+});
 
-        $this->assertEquals($expedtedOutput, $classified);
-    }
+it('targets deeply nested elements', function () {
+    Config::set('classify', ['default' => [
+        'a' => 'root-link',
+        'ul' => 'parent',
+        'ul li' => 'nested',
+        'ul li a' => 'first-nested-links',
+        'ul li ul' => 'nested-parent',
+        'ul li ul li' => 'nested-item',
+        'ul li ul li a' => 'deeply-nested-links',
+    ]]);
 
-    /** @test */
-    public function deeply_nested_elements_can_be_targeted()
-    {
-        $config = [
-            'default'  => [
-                'a' => 'root-link',
-                'ul' => 'parent',
-                'ul li' => 'nested',
-                'ul li a' => 'first-nested-links',
-                'ul li ul' => 'nested-parent',
-                'ul li ul li' => 'nested-item',
-                'ul li ul li a' => 'deeply-nested-links',
-            ],
-        ];
-
-        Config::set('classify', $config);
-
-        $bardInput = <<<'EOT'
+    $input = <<<'EOT'
  <a>Root link</a>
  <ul>
     <li><a>I am nested 1</a></li>
@@ -230,7 +137,7 @@ class ClassifyTest extends TestCase
  </ul>
  EOT;
 
-        $expedtedOutput = <<<'EOT'
+    $expected = <<<'EOT'
 <a class="root-link">Root link</a>
 <ul class="parent">
    <li class="nested"><a class="first-nested-links">I am nested 1</a></li>
@@ -246,30 +153,22 @@ class ClassifyTest extends TestCase
 </ul>
 EOT;
 
-        $classified = $this->classify->index($bardInput, [], []);
+    expect($this->classify->index($input, [], []))->toBe($expected);
+});
 
-        $this->assertEquals($expedtedOutput, $classified);
-    }
+it('targets deeply nested elements with css pseudo-selectors', function () {
+    Config::set('classify', ['default' => [
+        'a' => 'root-link',
+        'ul' => 'parent',
+        'ul li' => 'nested',
+        'ul li:nth-child(2n+2)' => 'nested nested-even',
+        'ul li a' => 'first-nested-links',
+        'ul li ul' => 'nested-parent',
+        'ul li ul li' => 'nested-item',
+        'ul li ul li a' => 'deeply-nested-links',
+    ]]);
 
-    /** @test */
-    public function deeply_nested_elements_can_be_targeted_with_css_selectors()
-    {
-        $config = [
-            'default'  => [
-                'a' => 'root-link',
-                'ul' => 'parent',
-                'ul li' => 'nested',
-                'ul li:nth-child(2n+2)' => 'nested nested-even',
-                'ul li a' => 'first-nested-links',
-                'ul li ul' => 'nested-parent',
-                'ul li ul li' => 'nested-item',
-                'ul li ul li a' => 'deeply-nested-links',
-            ],
-        ];
-
-        Config::set('classify', $config);
-
-        $bardInput = <<<'EOT'
+    $input = <<<'EOT'
  <a>Root link</a>
  <ul>
     <li><a>I am nested 1</a></li>
@@ -285,7 +184,7 @@ EOT;
  </ul>
  EOT;
 
-        $expedtedOutput = <<<'EOT'
+    $expected = <<<'EOT'
 <a class="root-link">Root link</a>
 <ul class="parent">
    <li class="nested"><a class="first-nested-links">I am nested 1</a></li>
@@ -301,28 +200,20 @@ EOT;
 </ul>
 EOT;
 
-        $classified = $this->classify->index($bardInput, [], []);
+    expect($this->classify->index($input, [], []))->toBe($expected);
+});
 
-        $this->assertEquals($expedtedOutput, $classified);
-    }
+it('falls back to root selector when no nested match exists', function () {
+    Config::set('classify', ['default' => [
+        'a' => 'root-link',
+        'ul' => 'parent',
+        'ul li' => 'nested',
+        'ul li a' => 'first-nested-links',
+        'ul li ul' => 'nested-parent',
+        'ul li ul li' => 'nested-item',
+    ]]);
 
-    /** @test */
-    public function root_link_class_is_applied_to_all_but_first_list_item_links()
-    {
-        $config = [
-            'default'  => [
-                'a' => 'root-link',
-                'ul' => 'parent',
-                'ul li' => 'nested',
-                'ul li a' => 'first-nested-links',
-                'ul li ul' => 'nested-parent',
-                'ul li ul li' => 'nested-item',
-            ],
-        ];
-
-        Config::set('classify', $config);
-
-        $bardInput = <<<'EOT'
+    $input = <<<'EOT'
  <a>Root link</a>
  <ul>
     <li><a>I am nested 1</a></li>
@@ -338,7 +229,7 @@ EOT;
  </ul>
  EOT;
 
-        $expedtedOutput = <<<'EOT'
+    $expected = <<<'EOT'
 <a class="root-link">Root link</a>
 <ul class="parent">
    <li class="nested"><a class="first-nested-links">I am nested 1</a></li>
@@ -354,72 +245,31 @@ EOT;
 </ul>
 EOT;
 
-        $classified = $this->classify->index($bardInput, [], []);
+    expect($this->classify->index($input, [], []))->toBe($expected);
+});
 
-        $this->assertEquals($expedtedOutput, $classified);
-    }
+it('handles an explicit body root in selectors', function () {
+    Config::set('classify', ['default' => ['body a span' => 'text-red']]);
 
-    /** @test */
-    public function adding_an_explicit_body_root_does_not_break_selectors()
-    {
-        $config = [
-            'default'  => [
-                'body a span' => 'text-red',
-            ],
-        ];
+    expect($this->classify->index('<a href="#">Some<span>thing</span></a>', [], []))
+        ->toBe('<a href="#">Some<span class="text-red">thing</span></a>');
+});
 
-        Config::set('classify', $config);
+it('normalizes excessive whitespace in selectors', function () {
+    Config::set('classify', ['default' => ['   a       span    ' => 'text-red']]);
 
-        $bardInput = '<a href="#">Some<span>thing</span></a>';
+    expect($this->classify->index('<a href="#">Some<span>thing</span></a>', [], []))
+        ->toBe('<a href="#">Some<span class="text-red">thing</span></a>');
+});
 
-        $classified = $this->classify->index($bardInput, [], []);
+it('handles explicit greater-than symbols without doubling selectors', function () {
+    Config::set('classify', ['default' => [' body >    a>span    ' => 'text-red']]);
 
-        $this->assertEquals('<a href="#">Some<span class="text-red">thing</span></a>', $classified);
-    }
+    expect($this->classify->index('<a href="#">Some<span>thing</span></a>', [], []))
+        ->toBe('<a href="#">Some<span class="text-red">thing</span></a>');
+});
 
-    /** @test */
-    public function adding_excessive_whitespace_produces_compatible_selectors()
-    {
-        $config = [
-            'default'  => [
-                '   a       span    ' => 'text-red',
-            ],
-        ];
-
-        Config::set('classify', $config);
-
-        $bardInput = '<a href="#">Some<span>thing</span></a>';
-
-        $classified = $this->classify->index($bardInput, [], []);
-
-        $this->assertEquals('<a href="#">Some<span class="text-red">thing</span></a>', $classified);
-    }
-
-    /** @test */
-    public function adding_explicit_greater_than_symbols_doesnt_double_up_internal_selectors()
-    {
-        $config = [
-            'default'  => [
-                ' body >    a>span    ' => 'text-red',
-            ],
-        ];
-
-        Config::set('classify', $config);
-
-        $bardInput = '<a href="#">Some<span>thing</span></a>';
-
-        $classified = $this->classify->index($bardInput, [], []);
-
-        $this->assertEquals('<a href="#">Some<span class="text-red">thing</span></a>', $classified);
-    }
-    
-    /** @test */
-    public function a_chained_selector_will_be_recognized()
-    {
-        $bardInput = '<strong>wonderful!</strong>';
-        
-        $classified = $this->classify->index($bardInput, [], []);
-        
-        $this->assertEquals('<strong class="text-red">wonderful!</strong>', $classified);
-    }
-}
+it('recognizes comma-separated selectors', function () {
+    expect($this->classify->index('<strong>wonderful!</strong>', [], []))
+        ->toBe('<strong class="text-red">wonderful!</strong>');
+});


### PR DESCRIPTION
## What

Includes the change from #48 (cherry-picked) plus:

- Convert PHPUnit test class to Pest 4
- Tighten dev deps: `pestphp/pest ^4.0`, `testbench ^9.17||^10.11||^11.0`
- Trim CI matrix: drop L10, S4, `prefer-lowest`; actually use `matrix.statamic` in install step
- Exclude impossible combos (L13+S5, L11+S6, L13+PHP 8.2)
- Update checkout action to v4

## Why

The existing CI was failing on `main` (14/44 jobs broken) due to:
1. **PHPUnit 12 dropped `@test` annotation support** — all tests used `/** @test */` with non-`test_` method names
2. **`matrix.statamic` was never used** in the install command — S4/S5 jobs were identical
3. **`prefer-lowest` pulled ancient testbench** versions that crash with `\$latestResponse` errors

Supersedes #48.